### PR TITLE
Upgrade snytax to be 0.13.x compatible

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Added some syntax that was not working with TF 0.13.x mainly the `triggers =` and the `versions =`

Also upgrade the syntax for TF 13 and added version file.